### PR TITLE
MacOS build fixes

### DIFF
--- a/gtsam/geometry/SL4.cpp
+++ b/gtsam/geometry/SL4.cpp
@@ -3,7 +3,7 @@
  * @brief Projective Special Linear Group (PSL(4, R)) Pose
  * @author: Hyungtae Lim
  */
-
+#include <cassert>
 #include <gtsam/geometry/SL4.h>
 
 // To use exp(), log()

--- a/gtsam/slam/TriangulationFactor.h
+++ b/gtsam/slam/TriangulationFactor.h
@@ -47,7 +47,7 @@ protected:
 
   // Keep a copy of measurement and calibration for I/O
   const CAMERA camera_; ///< CAMERA in which this landmark was seen
-  const Measurement measured_; ///< 2D measurement
+  Measurement measured_; ///< 2D measurement
 
   // verbosity handling for Cheirality Exceptions
   const bool throwCheirality_; ///< If true, rethrows Cheirality exceptions (default: false)


### PR DESCRIPTION
Fix two issues that prevented MacOS compilation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small build-focused changes: adds a missing standard header and relaxes a member from `const` to mutable storage; minimal behavioral impact but could affect code assuming `measured_` is immutable.
> 
> **Overview**
> Fixes macOS build failures by adding a missing `#include <cassert>` to `SL4.cpp` for the use of `assert`.
> 
> Adjusts `TriangulationFactor` to store `measured_` as non-`const` (was `const Measurement`), improving compatibility with compilers/operations that require assignable/movable factor instances (e.g., default construction/serialization/container use).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9689925874d1015e8ef8ea9e057b8ce53096b9a0. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->